### PR TITLE
fix: url,验签字符串带上请求参数biz_content

### DIFF
--- a/lib/alipay.ts
+++ b/lib/alipay.ts
@@ -123,7 +123,7 @@ class AlipaySdk {
         // const val = encodeURIComponent(params[key]);
         requestUrl = `${requestUrl}${ requestUrl.includes('?') ? '&' : '?' }${key}=${val}`;
         // 删除 postData 中对应的数据
-        if ( key === 'biz_content') continue;
+        if (key === 'biz_content') continue;
         delete params[key];
       }
     }


### PR DESCRIPTION
#13 对接生活缴费服务时URL上需要带biz_content参数，要不然会报验签不通过。