### PR TITLE
fix: 处理 multipartExec response 异常的情况

### DIFF
--- a/lib/alipay.ts
+++ b/lib/alipay.ts
@@ -213,7 +213,7 @@ class AlipaySdk {
         json: false,
         timeout: config.timeout,
         headers: { 'user-agent': this.sdkVersion },
-      }, (err, { }, body) => {
+      }, (err, _response, body) => {
         if (err) {
           err.message = '[AlipaySdk]exec error';
           errorLog && errorLog(err);
@@ -222,9 +222,16 @@ class AlipaySdk {
 
         infoLog && infoLog('[AlipaySdk]exec response: %s', body);
 
-        const result = JSON.parse(body);
-        const responseKey = `${method.replace(/\./g, '_')}_response`;
-        const data = result[responseKey];
+        let data, responseKey;
+
+        try {
+          const result = JSON.parse(body);
+          responseKey = `${method.replace(/\./g, '_')}_response`;
+          data = result[responseKey];
+        } catch (e) {
+          return reject({ serverResult: body, errorMessage: '[AlipaySdk]Response 格式错误' });
+        }
+        
 
         // 开放平台返回错误时，`${responseKey}` 对应的值不存在
         if (data) {

--- a/test/alipay.test.js
+++ b/test/alipay.test.js
@@ -548,6 +548,39 @@ describe('sdk', function() {
         });
     });
 
+    it('response parse error', function (done) {
+      const infoLog = [];
+      const errorLog = [];
+      const log = {
+        info(...args) { infoLog.push(args.join('')) },
+        error(...args) { errorLog.push(args.join('')) },
+      }
+      const filePath = path.join(__dirname, './fixtures/demo.jpg');
+
+      const form = new FormData();
+      form.addField('imageType', 'jpg');
+      form.addField('imageName', '海底捞.jpg');
+      form.addFile('imageContent', '海底捞.jpg', filePath);
+
+      sandbox.stub(sdk, 'checkResponseSign', function() { return false; });
+      sandbox.stub(request, 'post', function(option, callback) {
+        return callback(null, undefined , undefined);
+      });
+
+      sdk
+        .exec('alipay.offline.material.image.upload', {
+        }, { log, formData: form, validateSign: true })
+        .then(() => {
+          done();
+        }).catch(err => {
+          err.should.eql({
+            serverResult: undefined,
+            errorMessage: '[AlipaySdk]Response 格式错误',
+          });
+          done();
+        });
+    });
+
     it('camelcase is false', function(done) {
       const filePath = path.join(__dirname, './fixtures/demo.jpg');
 


### PR DESCRIPTION
在进行业务开发时，会偶现json parse失败问题，并且难以在sdk外部通过try catch捕获这类错误。