### PR TITLE
feat: AlipayFormData 支持文件流和文件内容上传文件

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,58 @@ console.log(uploadResult);
 // }
 ```
 
+#### 上传文件流
+
+```ts
+import fs from 'node:fs';
+import { AlipayFormData } from 'alipay-sdk';
+
+const form = new AlipayFormData();
+form.addFile('file_content', '图片.jpg', fs.createReadStream('/path/to/test-file'));
+
+const uploadResult = await alipaySdk.curl<{
+  file_id: string;
+}>('POST', '/v3/alipay/open/file/upload', {
+  form,
+  body: {
+    biz_code: 'openpt_appstore',
+  },
+});
+
+console.log(uploadResult);
+// {
+//   data: { file_id: 'A*7Cr9T6IAAC4AAAAAAAAAAAAAATcnAA' },
+//   responseHttpStatus: 200,
+//   traceId: '06033316171731110716358764348'
+// }
+```
+
+#### 上传文件内容
+
+```ts
+import fs from 'node:fs';
+import { AlipayFormData } from 'alipay-sdk';
+
+const form = new AlipayFormData();
+form.addFile('file_content', '图片.jpg', fs.readFileSync('/path/to/test-file'));
+
+const uploadResult = await alipaySdk.curl<{
+  file_id: string;
+}>('POST', '/v3/alipay/open/file/upload', {
+  form,
+  body: {
+    biz_code: 'openpt_appstore',
+  },
+});
+
+console.log(uploadResult);
+// {
+//   data: { file_id: 'A*7Cr9T6IAAC4AAAAAAAAAAAAAATcnAA' },
+//   responseHttpStatus: 200,
+//   traceId: '06033316171731110716358764348'
+// }
+```
+
 ### pageExecute 示例代码
 
 `pageExecute` 方法主要是用于网站支付接口请求链接生成，传入前台访问输入密码完成支付，

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bignumber.js": "^9.1.2",
     "camelcase-keys": "^7.0.2",
     "crypto-js": "^4.2.0",
-    "formstream": "^1.4.0",
+    "formstream": "^1.5.0",
     "snakecase-keys": "^8.0.0",
     "sse-decoder": "^1.0.0",
     "urllib": "^3.25.0",

--- a/src/AlipayFormStream.ts
+++ b/src/AlipayFormStream.ts
@@ -1,11 +1,16 @@
-// import { statSync } from 'node:fs';
 import FormStream from 'formstream';
 
+export interface AlipayFormStreamOptions {
+  /** min chunk size to emit data event */
+  minChunkSize?: number;
+}
+
 export class AlipayFormStream extends FormStream {
-  // 覆盖 file 方法，由于 OpenAPI 文件上传需要强制设置 content-length，所以需要增加一次同步文件 io 来实现此功能
-  // https://github.com/node-modules/formstream/blob/master/lib/formstream.js#L119
-  // file(name: string, filepath: string, filename: string) {
-  //   const size = statSync(filepath).size;
-  //   return super.file(name, filepath, filename, size);
-  // }
+  constructor(options?: AlipayFormStreamOptions) {
+    super({
+      // set default minChunkSize to 2MB
+      minChunkSize: 1024 * 1024 * 2,
+      ...options,
+    });
+  }
 }

--- a/src/alipay.ts
+++ b/src/alipay.ts
@@ -371,7 +371,13 @@ export class AlipaySdk {
           form.field('data', httpRequestBody, 'application/json');
           // 文件上传 https://opendocs.alipay.com/open-v3/054oog#%E6%96%87%E4%BB%B6%E4%B8%8A%E4%BC%A0
           for (const item of options.form.files) {
-            form.file(item.fieldName, item.path, item.name);
+            if (item.path) {
+              form.file(item.fieldName, item.path, item.name);
+            } else if (item.content) {
+              form.buffer(item.fieldName, item.content, item.name);
+            } else if (item.stream) {
+              form.stream(item.fieldName, item.stream, item.name);
+            }
           }
         } else if (options.form instanceof AlipayFormStream) {
           form = options.form;
@@ -507,8 +513,7 @@ export class AlipaySdk {
   async #multipartExec(method: string, options: IRequestOption): Promise<AlipaySdkCommonResult> {
     const config = this.config;
     let signParams = {} as Record<string, string>;
-    let formData = {} as { [key: string]: string | object };
-    const formFiles = {} as { [key: string]: string };
+    let formData = {} as Record<string, string>;
     options.formData!.getFields().forEach(field => {
       // formData 的字段类型应为 string。（兼容 null）
       const parsedFieldValue = typeof field.value === 'object' && field.value ?
@@ -521,12 +526,34 @@ export class AlipaySdk {
     // 签名方法中使用的 key 是驼峰
     signParams = camelcaseKeys(signParams, { deep: true });
     formData = snakeCaseKeys(formData);
+
+    const formStream = new AlipayFormStream();
+    for (const k in formData) {
+      formStream.field(k, formData[k]);
+    }
     options.formData!.getFiles().forEach(file => {
       // 文件名需要转换驼峰为下划线
       const fileKey = decamelize(file.fieldName);
       // 单独处理文件类型
-      formFiles[fileKey] = file.path;
+      if (file.path) {
+        formStream.file(fileKey, file.path, file.name);
+      } else if (file.stream) {
+        formStream.stream(fileKey, file.stream, file.name);
+      } else if (file.content) {
+        formStream.buffer(fileKey, file.content, file.name);
+      }
     });
+    const requestOptions: RequestOptions = {
+      method: 'POST',
+      dataType: 'text',
+      timeout: config.timeout,
+      headers: {
+        'user-agent': this.version,
+        accept: 'application/json',
+        ...formStream.headers(),
+      },
+      content: new Readable().wrap(formStream as any),
+    };
     // 计算签名
     const signData = sign(method, signParams, config);
     // 格式化 url
@@ -536,13 +563,7 @@ export class AlipaySdk {
       url, method, signParams);
     let httpResponse: HttpClientResponse<string>;
     try {
-      httpResponse = await urllib.request(url, {
-        timeout: config.timeout,
-        headers: { 'user-agent': this.version },
-        files: formFiles,
-        data: formData,
-        dataType: 'text',
-      });
+      httpResponse = await urllib.request(url, requestOptions);
     } catch (err: any) {
       debug('HttpClient Request error: %s', err);
       throw new AlipayRequestError(`HttpClient Request error: ${err.message}`, {

--- a/src/alipay.ts
+++ b/src/alipay.ts
@@ -504,7 +504,7 @@ export class AlipaySdk {
   }
 
   // 文件上传
-  async #multipartExec(method: string, options: IRequestOption = {}): Promise<AlipaySdkCommonResult> {
+  async #multipartExec(method: string, options: IRequestOption): Promise<AlipaySdkCommonResult> {
     const config = this.config;
     let signParams = {} as Record<string, string>;
     let formData = {} as { [key: string]: string | object };

--- a/src/util.ts
+++ b/src/util.ts
@@ -121,7 +121,7 @@ export function sign(method: string, params: Record<string, any>, config: Requir
   const algorithm = ALIPAY_ALGORITHM_MAPPING[config.signType];
   decamelizeParams.sign = createSign(algorithm)
     .update(signString, 'utf8').sign(config.privateKey, 'base64');
-  debug('algorithm: %s, signString: %o, sign: %o', algorithm, signString, sign);
+  debug('algorithm: %s, signString: %o, sign: %o', algorithm, signString, decamelizeParams.sign);
   return decamelizeParams;
 }
 

--- a/test/alipay.exec.test.ts
+++ b/test/alipay.exec.test.ts
@@ -1,5 +1,6 @@
 import { Verify } from 'node:crypto';
 import { strict as assert } from 'node:assert';
+import fs from 'node:fs';
 import urllib, { MockAgent, setGlobalDispatcher, getGlobalDispatcher } from 'urllib';
 import mm from 'mm';
 import {
@@ -523,6 +524,40 @@ describe('test/alipay.exec.test.ts', () => {
       assert(result.traceId!.length >= 29);
       assert(result.fileId);
       // console.log(result);
+    });
+
+    it('支持流式上传文件', async () => {
+      const filePath = getFixturesFile('demo.jpg');
+      const form = new AlipayFormData();
+      form.addField('biz_code', 'openpt_appstore');
+      form.addFile('file_content', '图片.jpg', fs.createReadStream(filePath));
+
+      const result = await sdk.exec('alipay.open.file.upload', {}, {
+        formData: form,
+        validateSign: true,
+      });
+      assert.equal(result.code, '10000');
+      assert.equal(result.msg, 'Success');
+      assert(result.traceId!.length >= 29);
+      assert(result.fileId);
+      console.log(result);
+    });
+
+    it('支持 buffer 上传文件', async () => {
+      const filePath = getFixturesFile('demo.jpg');
+      const form = new AlipayFormData();
+      form.addField('biz_code', 'openpt_appstore');
+      form.addFile('file_content', '图片.jpg', fs.readFileSync(filePath));
+
+      const result = await sdk.exec('alipay.open.file.upload', {}, {
+        formData: form,
+        validateSign: true,
+      });
+      assert.equal(result.code, '10000');
+      assert.equal(result.msg, 'Success');
+      assert(result.traceId!.length >= 29);
+      assert(result.fileId);
+      console.log(result);
     });
 
     it('should handle urllib request error', async () => {

--- a/test/alipay.test.ts
+++ b/test/alipay.test.ts
@@ -1,4 +1,6 @@
 import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { strict as assert } from 'node:assert';
 import urllib, { MockAgent, setGlobalDispatcher, getGlobalDispatcher } from 'urllib';
@@ -501,6 +503,29 @@ describe('test/alipay.test.ts', () => {
         },
       });
       console.log(uploadResult);
+      assert(uploadResult.data.file_id);
+      assert.equal(uploadResult.responseHttpStatus, 200);
+      assert(uploadResult.traceId);
+    });
+
+    it.skip('POST 文件上传大文件', async () => {
+      // https://opendocs.alipay.com/open-v3/5aa91070_alipay.open.file.upload?scene=common&pathHash=c8e11ccc
+      const filePath = path.join(os.homedir(), 'Downloads/foo.key.jpg');
+      const form = new (AlipayFormStream as any)({
+        minChunkSize: 2 * 1024 * 1024,
+      });
+      form.file('file_content', filePath, '图片.jpg');
+
+      const uploadResult = await sdk.curl<{
+        file_id: string;
+      }>('POST', '/v3/alipay/open/file/upload', {
+        form,
+        body: {
+          biz_code: 'openpt_appstore',
+        },
+        requestTimeout: 3000000,
+      });
+      // console.log(uploadResult);
       assert(uploadResult.data.file_id);
       assert.equal(uploadResult.responseHttpStatus, 200);
       assert(uploadResult.traceId);

--- a/test/alipay.test.ts
+++ b/test/alipay.test.ts
@@ -148,6 +148,48 @@ describe('test/alipay.test.ts', () => {
       assert(uploadResult.traceId);
     });
 
+    it('POST 文件上传，使用 AlipayFormData + stream', async () => {
+      // https://opendocs.alipay.com/open-v3/5aa91070_alipay.open.file.upload?scene=common&pathHash=c8e11ccc
+      const filePath = getFixturesFile('demo.jpg');
+      const form = new AlipayFormData();
+      form.addField('biz_code', 'openpt_appstore');
+      form.addField('foo', '{"bar":"bar value"}');
+      form.addField('foo-array', '[{"bar":"bar value"}]');
+      form.addFile('file_content', '图片.jpg', fs.createReadStream(filePath));
+
+      const uploadResult = await sdkStable.curl<{
+        file_id: string;
+      }>('POST', '/v3/alipay/open/file/upload', {
+        form,
+        requestTimeout: 10000,
+      });
+      // console.log(uploadResult);
+      assert(uploadResult.data.file_id);
+      assert.equal(uploadResult.responseHttpStatus, 200);
+      assert(uploadResult.traceId);
+    });
+
+    it('POST 文件上传，使用 AlipayFormData + buffer', async () => {
+      // https://opendocs.alipay.com/open-v3/5aa91070_alipay.open.file.upload?scene=common&pathHash=c8e11ccc
+      const filePath = getFixturesFile('demo.jpg');
+      const form = new AlipayFormData();
+      form.addField('biz_code', 'openpt_appstore');
+      form.addField('foo', '{"bar":"bar value"}');
+      form.addField('foo-array', '[{"bar":"bar value"}]');
+      form.addFile('file_content', '图片.jpg', fs.readFileSync(filePath));
+
+      const uploadResult = await sdkStable.curl<{
+        file_id: string;
+      }>('POST', '/v3/alipay/open/file/upload', {
+        form,
+        requestTimeout: 10000,
+      });
+      // console.log(uploadResult);
+      assert(uploadResult.data.file_id);
+      assert.equal(uploadResult.responseHttpStatus, 200);
+      assert(uploadResult.traceId);
+    });
+
     it('POST 文件上传，使用 AlipayFormData with body', async () => {
       // https://opendocs.alipay.com/open-v3/5aa91070_alipay.open.file.upload?scene=common&pathHash=c8e11ccc
       const filePath = getFixturesFile('demo.jpg');
@@ -472,7 +514,27 @@ describe('test/alipay.test.ts', () => {
       // https://opendocs.alipay.com/open-v3/5aa91070_alipay.open.file.upload?scene=common&pathHash=c8e11ccc
       const filePath = getFixturesFile('demo.jpg');
       const form = new AlipayFormStream();
-      form.file('file_content', filePath, 'demo.jpg');
+      form.file('file_content', filePath);
+
+      const uploadResult = await sdk.curl<{
+        file_id: string;
+      }>('POST', '/v3/alipay/open/file/upload', {
+        form,
+        body: {
+          biz_code: 'openpt_appstore',
+        },
+      });
+      // console.log(uploadResult);
+      assert(uploadResult.data.file_id);
+      assert.equal(uploadResult.responseHttpStatus, 200);
+      assert(uploadResult.traceId);
+    });
+
+    it('POST 文件上传，使用 AlipayFormStream with stream', async () => {
+      // https://opendocs.alipay.com/open-v3/5aa91070_alipay.open.file.upload?scene=common&pathHash=c8e11ccc
+      const filePath = getFixturesFile('demo.jpg');
+      const form = new AlipayFormStream();
+      form.stream('file_content', fs.createReadStream(filePath), 'demo.jpg');
 
       const uploadResult = await sdk.curl<{
         file_id: string;
@@ -511,9 +573,7 @@ describe('test/alipay.test.ts', () => {
     it.skip('POST 文件上传大文件', async () => {
       // https://opendocs.alipay.com/open-v3/5aa91070_alipay.open.file.upload?scene=common&pathHash=c8e11ccc
       const filePath = path.join(os.homedir(), 'Downloads/foo.key.jpg');
-      const form = new (AlipayFormStream as any)({
-        minChunkSize: 2 * 1024 * 1024,
-      });
+      const form = new AlipayFormStream();
       form.file('file_content', filePath, '图片.jpg');
 
       const uploadResult = await sdk.curl<{


### PR DESCRIPTION
fix: 设置文件上传分片 chunk 最小为 2MB, 避开 OpenAPI 接入层的 chunk 数量限制
基于 https://github.com/node-modules/formstream/pull/26 实现

closes https://github.com/alipay/alipay-sdk-nodejs-all/issues/130
closes https://github.com/alipay/alipay-sdk-nodejs-all/issues/135